### PR TITLE
Update metadata.php

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -31,7 +31,6 @@ $aModule = array(
     'controllers'       => array(
         'linslinexamplemodulemain' => \linslin\oxid6ExampleModule\Controller\Admin\MainController::class,
     ),
-    'files'       => array(),
     'templates'   => array(
         'main.tpl' => 'linslin/oxid6-example-module/views/admin/main.tpl'
     ),


### PR DESCRIPTION
Files array is not supported in metadata 2.0, therefore the module cannot be installed anymore in Oxid 6.2.0. As this module is a good example for developers, it would be nice to have a new version.